### PR TITLE
Fix thumb breakpoint addr parse

### DIFF
--- a/src/dwarf.ts
+++ b/src/dwarf.ts
@@ -168,7 +168,7 @@ export class Dwarf {
                             newCtx[reg]['symbol'] = symbol;
                         }
                         try {
-                            const inst = Instruction.parse(val);
+                            const inst = Instruction.parse(address_or_class);
                             newCtx[reg]['instruction'] = {
                                 'size': inst.size,
                                 'groups': inst.groups,

--- a/src/logic_breakpoint.ts
+++ b/src/logic_breakpoint.ts
@@ -208,7 +208,7 @@ export class LogicBreakpoint {
             breakpoint.interceptor.detach();
             Interceptor['flush']();
 
-            LogicBreakpoint.breakpoint(LogicBreakpoint.REASON_BREAKPOINT, this.context.pc,
+            LogicBreakpoint.breakpoint(LogicBreakpoint.REASON_BREAKPOINT, breakpoint.target,
                 this.context, null, breakpoint.condition);
 
             if (typeof LogicBreakpoint.breakpoints[breakpoint.target.toString()] !== 'undefined') {


### PR DESCRIPTION
We can't judge whether we are in thumb mode by `this.context.pc`.